### PR TITLE
Upgrade to Hugo 0.62.2

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,0 +1,38 @@
+{{ define "main" }}
+<main id="main">
+  <ul>
+		{{ range .Site.RegularPages.ByPublishDate.Reverse }}
+		{{ if .Params.pinToTop }}
+    <li>
+      <div id="list-item">
+        <a id="item-title" href="{{ .Permalink }}">{{ .Title }}</a>
+        <div id="date-and-tags">
+          {{ partial "date/date.html" . }}
+          {{ partial "tags/tags.html" . }}
+        </div>
+        <p id="item-desc">
+          {{ .Params.desc }}
+        </p>
+      </div>
+    </li>
+		{{ end }}
+		{{ end }}
+		{{ range .Site.RegularPages.ByPublishDate.Reverse }}
+		{{ if not .Params.pinToTop }}
+    <li>
+      <div id="list-item">
+        <a id="item-title" href="{{ .Permalink }}">{{ .Title }}</a>
+        <div id="date-and-tags">
+          {{ partial "date/date.html" . }}
+          {{ partial "tags/tags.html" . }}
+        </div>
+        <p id="item-desc">
+          {{ .Params.desc }}
+        </p>
+      </div>
+    </li>
+		{{ end }}
+		{{ end }}
+  </ul>
+</main>
+{{ end }}


### PR DESCRIPTION
Hugo 0.62.2 introduced some changes that cause the homepage to not be able to render properly (only sections can be rendered). Solution is create a `layout/index.html` file that renders only `.Site.RegularPages`.